### PR TITLE
Add support for update-ref

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -23,6 +23,9 @@ m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
 .       create a merge commit using the original merge commit's
 .       message (or the oneline, if no original merge commit was
 .       specified); use -c <commit> to reword the commit message
+u, update-ref <ref> = track a placeholder for the <ref> to be updated
+                      to this position in the new commits. The <ref> is
+                      updated at the end of the rebase
 ```
 
 ## Example

--- a/todo/fixtures/todo1
+++ b/todo/fixtures/todo1
@@ -4,6 +4,7 @@ reset somecommit
 # comment
 exec cd subdir; make test
 l awesomecommit
+update-ref refs/heads/my-branch
 merge -C 6f5e4d report-a-bug # Merge 'report-a-bug'
 fixup -C abbaceef
 break

--- a/todo/parse.go
+++ b/todo/parse.go
@@ -55,9 +55,9 @@ func parseLine(line string) (Todo, error) {
 
 	fields := strings.Fields(line)
 
-	for i := TodoCommand(Pick); i < Comment; i++ {
+	for i := Pick; i < Comment; i++ {
 		if isCommand(i, fields[0]) {
-			todo.Command = TodoCommand(i)
+			todo.Command = i
 			fields = fields[1:]
 			break
 		}

--- a/todo/parse.go
+++ b/todo/parse.go
@@ -13,6 +13,7 @@ var (
 	ErrMissingLabel      = errors.New("missing label")
 	ErrMissingCommit     = errors.New("missing commit")
 	ErrMissingExecCmd    = errors.New("missing command for exec")
+	ErrMissingRef        = errors.New("missing ref")
 )
 
 func Parse(f io.Reader) ([]Todo, error) {
@@ -117,6 +118,14 @@ func parseLine(line string) (Todo, error) {
 		if fields[0] == "-C" || fields[0] == "-c" {
 			fields = fields[1:]
 		}
+	}
+
+	if todo.Command == UpdateRef {
+		if len(fields) == 0 {
+			return todo, ErrMissingRef
+		}
+		todo.Ref = fields[0]
+		return todo, nil
 	}
 
 	if len(fields) == 0 {

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -1,11 +1,10 @@
-package todo_test
+package todo
 
 import (
 	"os"
 	"reflect"
 	"testing"
 
-	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,36 +12,36 @@ func TestParse(t *testing.T) {
 	tests := []struct {
 		name        string
 		inputPath   string
-		expect      []todo.Todo
+		expect      []Todo
 		expectError error
 	}{
-		{name: "basic", inputPath: "./fixtures/todo1", expect: []todo.Todo{
-			{Command: todo.Pick, Commit: "deadbeef", Msg: "My commit msg"},
-			{Command: todo.Pick, Commit: "beefdead", Msg: "Another awesome commit"},
-			{Command: todo.Reset, Label: "somecommit"},
-			{Command: todo.Comment, Comment: " comment"},
-			{Command: todo.Exec, ExecCommand: "cd subdir; make test"},
-			{Command: todo.Label, Label: "awesomecommit"},
-			{Command: todo.Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
-			{Command: todo.Fixup, Commit: "abbaceef"},
-			{Command: todo.Break},
+		{name: "basic", inputPath: "./fixtures/todo1", expect: []Todo{
+			{Command: Pick, Commit: "deadbeef", Msg: "My commit msg"},
+			{Command: Pick, Commit: "beefdead", Msg: "Another awesome commit"},
+			{Command: Reset, Label: "somecommit"},
+			{Command: Comment, Comment: " comment"},
+			{Command: Exec, ExecCommand: "cd subdir; make test"},
+			{Command: Label, Label: "awesomecommit"},
+			{Command: Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
+			{Command: Fixup, Commit: "abbaceef"},
+			{Command: Break},
 		}},
-		{name: "missing exec cmd", inputPath: "./fixtures/missing_exec_cmd", expectError: todo.ErrMissingExecCmd},
-		{name: "missing label", inputPath: "./fixtures/missing_label", expectError: todo.ErrMissingLabel},
-		{name: "example from git website", inputPath: "./fixtures/git_example", expect: []todo.Todo{
-			{Command: todo.Label, Label: "onto"},
-			{Command: todo.Comment, Comment: " Branch: refactor-button"},
-			{Command: todo.Reset, Label: "onto"},
-			{Command: todo.Pick, Commit: "123456", Msg: "Extract a generic Button class from the DownloadButton one"},
-			{Command: todo.Pick, Commit: "654321", Msg: "Use the Button class for all buttons"},
-			{Command: todo.Label, Label: "refactor-button"},
-			{Command: todo.Comment, Comment: " Branch: report-a-bug"},
-			{Command: todo.Reset, Label: "refactor-button"},
-			{Command: todo.Pick, Commit: "abcdef", Msg: "Add the feedback button"},
-			{Command: todo.Label, Label: "report-a-bug"},
-			{Command: todo.Reset, Label: "onto"},
-			{Command: todo.Merge, Commit: "a1b2c3", Label: "refactor-button", Msg: "Merge 'refactor-button'"},
-			{Command: todo.Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
+		{name: "missing exec cmd", inputPath: "./fixtures/missing_exec_cmd", expectError: ErrMissingExecCmd},
+		{name: "missing label", inputPath: "./fixtures/missing_label", expectError: ErrMissingLabel},
+		{name: "example from git website", inputPath: "./fixtures/git_example", expect: []Todo{
+			{Command: Label, Label: "onto"},
+			{Command: Comment, Comment: " Branch: refactor-button"},
+			{Command: Reset, Label: "onto"},
+			{Command: Pick, Commit: "123456", Msg: "Extract a generic Button class from the DownloadButton one"},
+			{Command: Pick, Commit: "654321", Msg: "Use the Button class for all buttons"},
+			{Command: Label, Label: "refactor-button"},
+			{Command: Comment, Comment: " Branch: report-a-bug"},
+			{Command: Reset, Label: "refactor-button"},
+			{Command: Pick, Commit: "abcdef", Msg: "Add the feedback button"},
+			{Command: Label, Label: "report-a-bug"},
+			{Command: Reset, Label: "onto"},
+			{Command: Merge, Commit: "a1b2c3", Label: "refactor-button", Msg: "Merge 'refactor-button'"},
+			{Command: Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
 		}},
 	}
 
@@ -53,7 +52,7 @@ func TestParse(t *testing.T) {
 
 			defer f.Close()
 
-			result, err := todo.Parse(f)
+			result, err := Parse(f)
 
 			if tt.expectError != nil {
 				require.ErrorIs(t, err, tt.expectError)

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -22,6 +22,7 @@ func TestParse(t *testing.T) {
 			{Command: Comment, Comment: " comment"},
 			{Command: Exec, ExecCommand: "cd subdir; make test"},
 			{Command: Label, Label: "awesomecommit"},
+			{Command: UpdateRef, Ref: "refs/heads/my-branch"},
 			{Command: Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
 			{Command: Fixup, Commit: "abbaceef"},
 			{Command: Break},

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -1,7 +1,6 @@
 package todo_test
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -9,11 +8,6 @@ import (
 	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/stretchr/testify/require"
 )
-
-func readFixture(name string) []byte {
-	bytes, _ := ioutil.ReadFile("./fixtures/" + name)
-	return bytes
-}
 
 func TestParse(t *testing.T) {
 	tests := []struct {

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -49,9 +49,9 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f, err := os.Open(tt.inputPath)
-			defer f.Close()
-
 			require.NoError(t, err)
+
+			defer f.Close()
 
 			result, err := todo.Parse(f)
 

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -18,6 +18,7 @@ const (
 
 	NoOp
 	Drop
+	UpdateRef
 
 	Comment
 )
@@ -31,6 +32,7 @@ type Todo struct {
 	ExecCommand string
 	Label       string
 	Msg         string
+	Ref         string
 }
 
 func (t TodoCommand) String() string {
@@ -38,23 +40,24 @@ func (t TodoCommand) String() string {
 }
 
 var commandToString = map[TodoCommand]string{
-	Pick:    "pick",
-	Revert:  "revert",
-	Edit:    "edit",
-	Reword:  "reword",
-	Fixup:   "fixup",
-	Squash:  "squash",
-	Exec:    "exec",
-	Break:   "break",
-	Label:   "label",
-	Reset:   "reset",
-	Merge:   "merge",
-	NoOp:    "noop",
-	Drop:    "drop",
-	Comment: "comment",
+	Pick:      "pick",
+	Revert:    "revert",
+	Edit:      "edit",
+	Reword:    "reword",
+	Fixup:     "fixup",
+	Squash:    "squash",
+	Exec:      "exec",
+	Break:     "break",
+	Label:     "label",
+	Reset:     "reset",
+	Merge:     "merge",
+	NoOp:      "noop",
+	Drop:      "drop",
+	UpdateRef: "update-ref",
+	Comment:   "comment",
 }
 
-var todoCommandInfo = [14]struct {
+var todoCommandInfo = [15]struct {
 	nickname string
 	cmd      string
 }{
@@ -72,4 +75,5 @@ var todoCommandInfo = [14]struct {
 	{"m", "merge"},
 	{"", "noop"},
 	{"d", "drop"},
+	{"u", "update-ref"},
 }


### PR DESCRIPTION
This adds support for the `update-ref` command that was added in git 2.38.0.

Also, fix a few minor things here and there.