### PR TITLE
Add Write function

### DIFF
--- a/todo/parse.go
+++ b/todo/parse.go
@@ -91,6 +91,7 @@ func parseLine(line string) (Todo, error) {
 
 	if todo.Command == Merge {
 		if fields[0] == "-C" || fields[0] == "-c" {
+			todo.Flag = fields[0]
 			fields = fields[1:]
 			if len(fields) == 0 {
 				return todo, ErrMissingCommit
@@ -116,6 +117,7 @@ func parseLine(line string) (Todo, error) {
 		}
 		// Skip flags
 		if fields[0] == "-C" || fields[0] == "-c" {
+			todo.Flag = fields[0]
 			fields = fields[1:]
 		}
 	}

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -23,8 +23,8 @@ func TestParse(t *testing.T) {
 			{Command: Exec, ExecCommand: "cd subdir; make test"},
 			{Command: Label, Label: "awesomecommit"},
 			{Command: UpdateRef, Ref: "refs/heads/my-branch"},
-			{Command: Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
-			{Command: Fixup, Commit: "abbaceef"},
+			{Command: Merge, Commit: "6f5e4d", Flag: "-C", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
+			{Command: Fixup, Commit: "abbaceef", Flag: "-C"},
 			{Command: Break},
 		}},
 		{name: "missing exec cmd", inputPath: "./fixtures/missing_exec_cmd", expectError: ErrMissingExecCmd},
@@ -41,8 +41,8 @@ func TestParse(t *testing.T) {
 			{Command: Pick, Commit: "abcdef", Msg: "Add the feedback button"},
 			{Command: Label, Label: "report-a-bug"},
 			{Command: Reset, Label: "onto"},
-			{Command: Merge, Commit: "a1b2c3", Label: "refactor-button", Msg: "Merge 'refactor-button'"},
-			{Command: Merge, Commit: "6f5e4d", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
+			{Command: Merge, Commit: "a1b2c3", Flag: "-C", Label: "refactor-button", Msg: "Merge 'refactor-button'"},
+			{Command: Merge, Commit: "6f5e4d", Flag: "-C", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
 		}},
 	}
 

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -28,6 +28,7 @@ const CommentChar = "#"
 type Todo struct {
 	Command     TodoCommand
 	Commit      string
+	Flag        string
 	Comment     string
 	ExecCommand string
 	Label       string

--- a/todo/write.go
+++ b/todo/write.go
@@ -1,0 +1,92 @@
+package todo
+
+import (
+	"io"
+	"strings"
+)
+
+func Write(f io.Writer, todos []Todo) error {
+	for _, todo := range todos {
+		if err := writeTodo(f, todo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeTodo(f io.Writer, todo Todo) error {
+	var sb strings.Builder
+	if todo.Command != Comment {
+		sb.WriteString(todo.Command.String())
+	}
+
+	switch todo.Command {
+	case NoOp:
+		return nil
+
+	case Comment:
+		sb.WriteString(CommentChar)
+		sb.WriteString(todo.Comment)
+
+	case Break:
+
+	case Label:
+		fallthrough
+	case Reset:
+		sb.WriteByte(' ')
+		sb.WriteString(todo.Label)
+
+	case Exec:
+		sb.WriteByte(' ')
+		sb.WriteString(todo.ExecCommand)
+
+	case Merge:
+		sb.WriteByte(' ')
+		if todo.Commit != "" {
+			sb.WriteString(todo.Flag)
+			sb.WriteByte(' ')
+			sb.WriteString(todo.Commit)
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(todo.Label)
+		if todo.Msg != "" {
+			sb.WriteString(" # ")
+			sb.WriteString(todo.Msg)
+		}
+
+	case Fixup:
+		sb.WriteByte(' ')
+		if todo.Flag != "" {
+			sb.WriteString(todo.Flag)
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(todo.Commit)
+
+	case UpdateRef:
+		sb.WriteByte(' ')
+		sb.WriteString(todo.Ref)
+
+	case Pick:
+		fallthrough
+	case Revert:
+		fallthrough
+	case Edit:
+		fallthrough
+	case Reword:
+		fallthrough
+	case Squash:
+		fallthrough
+	case Drop:
+		sb.WriteByte(' ')
+		sb.WriteString(todo.Commit)
+		if todo.Msg != "" {
+			sb.WriteByte(' ')
+			sb.WriteString(todo.Msg)
+		}
+	}
+
+	sb.WriteByte('\n')
+	_, err := f.Write([]byte(sb.String()))
+	return err
+}

--- a/todo/write_test.go
+++ b/todo/write_test.go
@@ -1,0 +1,85 @@
+package todo
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrite(t *testing.T) {
+	tests := []struct {
+		name     string
+		todos    []Todo
+		expected string
+	}{
+		{
+			"todo1",
+			[]Todo{
+				{Command: Pick, Commit: "deadbeef", Msg: "My commit msg"},
+				{Command: Pick, Commit: "beefdead", Msg: "Another awesome commit"},
+				{Command: Reset, Label: "somecommit"},
+				{Command: Comment, Comment: " comment"},
+				{Command: Exec, ExecCommand: "cd subdir; make test"},
+				{Command: Label, Label: "awesomecommit"},
+				{Command: UpdateRef, Ref: "refs/heads/my-branch"},
+				{Command: Merge, Commit: "6f5e4d", Flag: "-C", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
+				{Command: Fixup, Commit: "abbaceef"},
+				{Command: Break},
+			},
+			`pick deadbeef My commit msg
+pick beefdead Another awesome commit
+reset somecommit
+# comment
+exec cd subdir; make test
+label awesomecommit
+update-ref refs/heads/my-branch
+merge -C 6f5e4d report-a-bug # Merge 'report-a-bug'
+fixup abbaceef
+break
+`,
+		},
+		{
+			"example from git website",
+			[]Todo{
+				{Command: Label, Label: "onto"},
+				{Command: Comment, Comment: " Branch: refactor-button"},
+				{Command: Reset, Label: "onto"},
+				{Command: Pick, Commit: "123456", Msg: "Extract a generic Button class from the DownloadButton one"},
+				{Command: Pick, Commit: "654321", Msg: "Use the Button class for all buttons"},
+				{Command: Label, Label: "refactor-button"},
+				{Command: Comment, Comment: " Branch: report-a-bug"},
+				{Command: Reset, Label: "refactor-button"},
+				{Command: Pick, Commit: "abcdef", Msg: "Add the feedback button"},
+				{Command: Label, Label: "report-a-bug"},
+				{Command: Reset, Label: "onto"},
+				{Command: Merge, Commit: "a1b2c3", Flag: "-C", Label: "refactor-button", Msg: "Merge 'refactor-button'"},
+				{Command: Merge, Commit: "6f5e4d", Flag: "-c", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
+			},
+			`label onto
+# Branch: refactor-button
+reset onto
+pick 123456 Extract a generic Button class from the DownloadButton one
+pick 654321 Use the Button class for all buttons
+label refactor-button
+# Branch: report-a-bug
+reset refactor-button
+pick abcdef Add the feedback button
+label report-a-bug
+reset onto
+merge -C a1b2c3 refactor-button # Merge 'refactor-button'
+merge -c 6f5e4d report-a-bug # Merge 'report-a-bug'
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &bytes.Buffer{}
+			err := Write(f, tt.todos)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, f.String())
+		})
+	}
+}


### PR DESCRIPTION
This adds a Write function that writes a list of todos back to a file. This can be useful for parsing a git-rebase-todo file, making a change to one of the entries (e.g. change one from "pick" to "edit"), and writing it back out.