### PR TITLE
Add comment character parameter

### DIFF
--- a/todo/fixtures/custom_comment_char
+++ b/todo/fixtures/custom_comment_char
@@ -1,0 +1,10 @@
+label onto
+
+; Branch dev
+reset onto
+pick 086d35c one
+label dev
+
+reset onto
+pick ad56c2e two
+merge -C 1c87252 dev # Merge branch 'dev'

--- a/todo/parse.go
+++ b/todo/parse.go
@@ -16,7 +16,7 @@ var (
 	ErrMissingRef        = errors.New("missing ref")
 )
 
-func Parse(f io.Reader) ([]Todo, error) {
+func Parse(f io.Reader, commentChar byte) ([]Todo, error) {
 	var result []Todo
 
 	scanner := bufio.NewScanner(f)
@@ -30,7 +30,7 @@ func Parse(f io.Reader) ([]Todo, error) {
 			continue
 		}
 
-		cmd, err := parseLine(line)
+		cmd, err := parseLine(line, commentChar)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse line %q: %w", line, err)
 		}
@@ -45,12 +45,12 @@ func Parse(f io.Reader) ([]Todo, error) {
 	return result, nil
 }
 
-func parseLine(line string) (Todo, error) {
+func parseLine(line string, commentChar byte) (Todo, error) {
 	var todo Todo
 
-	if strings.HasPrefix(line, CommentChar) {
+	if line[0] == commentChar {
 		todo.Command = Comment
-		todo.Comment = strings.TrimLeft(line, CommentChar)
+		todo.Comment = line[1:]
 		return todo, nil
 	}
 
@@ -143,8 +143,8 @@ func parseLine(line string) (Todo, error) {
 	todo.Commit = fields[0]
 	fields = fields[1:]
 
-	// Trim # and whitespace
-	todo.Msg = strings.TrimPrefix(strings.Join(fields, " "), CommentChar+" ")
+	// Trim comment char and whitespace
+	todo.Msg = strings.TrimPrefix(strings.Join(fields, " "), fmt.Sprintf("%c ", commentChar))
 
 	return todo, nil
 }

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -12,10 +12,11 @@ func TestParse(t *testing.T) {
 	tests := []struct {
 		name        string
 		inputPath   string
+		commentChar byte
 		expect      []Todo
 		expectError error
 	}{
-		{name: "basic", inputPath: "./fixtures/todo1", expect: []Todo{
+		{name: "basic", inputPath: "./fixtures/todo1", commentChar: '#', expect: []Todo{
 			{Command: Pick, Commit: "deadbeef", Msg: "My commit msg"},
 			{Command: Pick, Commit: "beefdead", Msg: "Another awesome commit"},
 			{Command: Reset, Label: "somecommit"},
@@ -30,9 +31,9 @@ func TestParse(t *testing.T) {
 			{Command: Fixup, Commit: "abbaceef", Flag: "-C"},
 			{Command: Break},
 		}},
-		{name: "missing exec cmd", inputPath: "./fixtures/missing_exec_cmd", expectError: ErrMissingExecCmd},
-		{name: "missing label", inputPath: "./fixtures/missing_label", expectError: ErrMissingLabel},
-		{name: "example from git website", inputPath: "./fixtures/git_example", expect: []Todo{
+		{name: "missing exec cmd", inputPath: "./fixtures/missing_exec_cmd", commentChar: '#', expectError: ErrMissingExecCmd},
+		{name: "missing label", inputPath: "./fixtures/missing_label", commentChar: '#', expectError: ErrMissingLabel},
+		{name: "example from git website", inputPath: "./fixtures/git_example", commentChar: '#', expect: []Todo{
 			{Command: Label, Label: "onto"},
 			{Command: Comment, Comment: " Branch: refactor-button"},
 			{Command: Reset, Label: "onto"},
@@ -47,6 +48,16 @@ func TestParse(t *testing.T) {
 			{Command: Merge, Commit: "a1b2c3", Flag: "-C", Label: "refactor-button", Msg: "Merge 'refactor-button'"},
 			{Command: Merge, Commit: "6f5e4d", Flag: "-C", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
 		}},
+		{name: "custom comment char", inputPath: "./fixtures/custom_comment_char", commentChar: ';', expect: []Todo{
+			{Command: Label, Label: "onto"},
+			{Command: Comment, Comment: " Branch dev"},
+			{Command: Reset, Label: "onto"},
+			{Command: Pick, Commit: "086d35c", Msg: "one"},
+			{Command: Label, Label: "dev"},
+			{Command: Reset, Label: "onto"},
+			{Command: Pick, Commit: "ad56c2e", Msg: "two"},
+			{Command: Merge, Commit: "1c87252", Flag: "-C", Label: "dev", Msg: "Merge branch 'dev'"},
+		}},
 	}
 
 	for _, tt := range tests {
@@ -56,7 +67,7 @@ func TestParse(t *testing.T) {
 
 			defer f.Close()
 
-			result, err := Parse(f)
+			result, err := Parse(f, tt.commentChar)
 
 			if tt.expectError != nil {
 				require.ErrorIs(t, err, tt.expectError)

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -23,8 +23,6 @@ const (
 	Comment
 )
 
-const CommentChar = "#"
-
 type Todo struct {
 	Command     TodoCommand
 	Commit      string

--- a/todo/write.go
+++ b/todo/write.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-func Write(f io.Writer, todos []Todo) error {
+func Write(f io.Writer, todos []Todo, commentChar byte) error {
 	for _, todo := range todos {
-		if err := writeTodo(f, todo); err != nil {
+		if err := writeTodo(f, todo, commentChar); err != nil {
 			return err
 		}
 	}
@@ -15,7 +15,7 @@ func Write(f io.Writer, todos []Todo) error {
 	return nil
 }
 
-func writeTodo(f io.Writer, todo Todo) error {
+func writeTodo(f io.Writer, todo Todo, commentChar byte) error {
 	var sb strings.Builder
 	if todo.Command != Comment {
 		sb.WriteString(todo.Command.String())
@@ -26,7 +26,7 @@ func writeTodo(f io.Writer, todo Todo) error {
 		return nil
 
 	case Comment:
-		sb.WriteString(CommentChar)
+		sb.WriteByte(commentChar)
 		sb.WriteString(todo.Comment)
 
 	case Break:


### PR DESCRIPTION
This adds `commentChar` parameter to both `Write` and `Parse` functions. More details at https://github.com/fsmiamoto/git-todo-parser/issues/5.