### PR TITLE
Fix parsing and writing of noop command

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,6 +26,7 @@ m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
 u, update-ref <ref> = track a placeholder for the <ref> to be updated
                       to this position in the new commits. The <ref> is
                       updated at the end of the rebase
+noop = do nothing
 ```
 
 ## Example

--- a/.github/README.md
+++ b/.github/README.md
@@ -20,9 +20,9 @@ d, drop <commit> = remove commit
 l, label <label> = label current HEAD with a name
 t, reset <label> = reset HEAD to a label
 m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
-.       create a merge commit using the original merge commit's
-.       message (or the oneline, if no original merge commit was
-.       specified); use -c <commit> to reword the commit message
+        create a merge commit using the original merge commit's
+        message (or the oneline, if no original merge commit was
+        specified); use -c <commit> to reword the commit message
 u, update-ref <ref> = track a placeholder for the <ref> to be updated
                       to this position in the new commits. The <ref> is
                       updated at the end of the rebase

--- a/todo/fixtures/todo1
+++ b/todo/fixtures/todo1
@@ -11,3 +11,4 @@ update-ref refs/heads/my-branch
 merge -C 6f5e4d report-a-bug # Merge 'report-a-bug'
 fixup -C abbaceef
 break
+noop

--- a/todo/parse.go
+++ b/todo/parse.go
@@ -71,7 +71,7 @@ func parseLine(line string, commentChar byte) (Todo, error) {
 		return todo, ErrUnexpectedCommand
 	}
 
-	if todo.Command == Break {
+	if todo.Command == Break || todo.Command == NoOp {
 		return todo, nil
 	}
 

--- a/todo/parse_test.go
+++ b/todo/parse_test.go
@@ -30,6 +30,7 @@ func TestParse(t *testing.T) {
 			{Command: Merge, Commit: "6f5e4d", Flag: "-C", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
 			{Command: Fixup, Commit: "abbaceef", Flag: "-C"},
 			{Command: Break},
+			{Command: NoOp},
 		}},
 		{name: "missing exec cmd", inputPath: "./fixtures/missing_exec_cmd", commentChar: '#', expectError: ErrMissingExecCmd},
 		{name: "missing label", inputPath: "./fixtures/missing_label", commentChar: '#', expectError: ErrMissingLabel},

--- a/todo/write.go
+++ b/todo/write.go
@@ -23,7 +23,6 @@ func writeTodo(f io.Writer, todo Todo, commentChar byte) error {
 
 	switch todo.Command {
 	case NoOp:
-		return nil
 
 	case Comment:
 		sb.WriteByte(commentChar)

--- a/todo/write_test.go
+++ b/todo/write_test.go
@@ -35,6 +35,7 @@ func testWrite(t *testing.T, commentChar byte) {
 				{Command: Merge, Commit: "6f5e4d", Flag: "-C", Label: "report-a-bug", Msg: "Merge 'report-a-bug'"},
 				{Command: Fixup, Commit: "abbaceef"},
 				{Command: Break},
+				{Command: NoOp},
 			},
 			fmt.Sprintf(`pick deadbeef My commit msg
 pick beefdead Another awesome commit
@@ -46,6 +47,7 @@ update-ref refs/heads/my-branch
 merge -C 6f5e4d report-a-bug # Merge 'report-a-bug'
 fixup abbaceef
 break
+noop
 `, commentChar),
 		},
 		{


### PR DESCRIPTION
When parsing a todo file that contains `noop` commands, we would fail with the error `failed to parse line "noop": missing commit`.